### PR TITLE
mappings.h: route __APPLE__ to desktop GL 2.1 instead of broken iOS path

### DIFF
--- a/mappings.h
+++ b/mappings.h
@@ -46,13 +46,16 @@
 #endif
 
 
-#ifdef __APPLE__ 
-#include "platform_utils.h"
-#define IOS
-#endif
-
 #ifdef ANDROID
 #include <android/log.h> // this is needed to make android logging working.
+#define PTHREAD
+#endif
+
+#ifdef __APPLE__
+// macOS desktop OpenGL — GLES 2.0 is a strict subset of the GL 2.1 surface
+// Apple's <OpenGL/gl.h> exposes. iOS still needs a different code path; if/when
+// we target iOS, gate that on TARGET_OS_IPHONE rather than __APPLE__.
+#define USE_DESKTOP_GL
 #define PTHREAD
 #endif
 
@@ -63,7 +66,11 @@
 
 #ifndef USE_OPENGL
 
-#ifdef IOS
+#ifdef USE_DESKTOP_GL
+#define GL_SILENCE_DEPRECATION 1
+#include <OpenGL/gl.h>
+#include <OpenGL/glext.h>
+#elif defined(IOS)
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
 #else


### PR DESCRIPTION
## Problem

The current `__APPLE__` branch in `mappings.h` does two things that prevent macOS dev builds:

1. `#include "platform_utils.h"` — this header doesn't exist anywhere in the repo.
2. `#define IOS` — pulls `<OpenGLES/ES2/gl.h>` further down, which is only present in the iOS SDK, not the macOS SDK.

Net effect: any consumer that includes `gain.h` on macOS fails to compile.

## Fix

Add a `USE_DESKTOP_GL` path that includes `<OpenGL/gl.h>` + `<OpenGL/glext.h>` (and `GL_SILENCE_DEPRECATION`) on `__APPLE__`. Apple's legacy 2.1 desktop profile is a strict superset of the GLES 2.0 surface gainlib actually uses (FBO + shaders + VBOs + glDraw* — no `glClearDepthf` or other GLES-only entry points).

iOS targets are unchanged in spirit but should gate on `TARGET_OS_IPHONE` rather than `__APPLE__` when re-introduced — the current PR removes the iOS branch entirely since it was already broken on macOS via the shared `__APPLE__` define. Happy to add a `TARGET_OS_IPHONE` guard back if you want it preserved.

## Verification

Built and ran on macOS 25.4 (Apple clang 21) against a downstream consumer (TriRamp) with this submodule pin: cmake configure + build clean, GL client opens a 1024x768 window, all gainlib calls (programs, FBOs, VBOs, glDrawArrays, etc.) work against `<OpenGL/gl.h>` 2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)